### PR TITLE
Fix remote icons (should be https)

### DIFF
--- a/com.jagex.RuneScape.appdata.xml
+++ b/com.jagex.RuneScape.appdata.xml
@@ -13,14 +13,14 @@
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">http://www.runescape.com/</url>
   <!-- These are the icons for the Android app, https://play.google.com/store/apps/details?id=com.jagex.RSCompanion -->
-  <icon type="remote" height="16" width="16">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w16</icon>
-  <icon type="remote" height="24" width="24">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w24</icon>
-  <icon type="remote" height="32" width="32">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w32</icon>
-  <icon type="remote" height="48" width="48">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w48</icon>
-  <icon type="remote" height="64" width="64">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w64</icon>
-  <icon type="remote" height="128" width="128">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w128</icon>
-  <icon type="remote" height="256" width="256">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w256</icon>
-  <icon type="remote" height="512" width="512">http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w512</icon>
+  <icon type="remote" height="16" width="16">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w16</icon>
+  <icon type="remote" height="24" width="24">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w24</icon>
+  <icon type="remote" height="32" width="32">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w32</icon>
+  <icon type="remote" height="48" width="48">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w48</icon>
+  <icon type="remote" height="64" width="64">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w64</icon>
+  <icon type="remote" height="128" width="128">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w128</icon>
+  <icon type="remote" height="256" width="256">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w256</icon>
+  <icon type="remote" height="512" width="512">https://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w512</icon>
   <kudos>
     <kudo>HiDpiIcon</kudo>
   </kudos>


### PR DESCRIPTION
In https://beta.flathub.org/apps Firefox and Chrome don't show the icon for this app because they expect it to be served with https

Browser console:
/apps:1 Mixed Content: The page at 'https://beta.flathub.org/apps' was loaded over HTTPS, but requested an insecure image 'http://lh3.googleusercontent.com/2J5PH-QM9n7DjmdJx4EQZq1t4o6Wc0NBkI2RyRiggAOgLf4mupfSXcrC5Jd0vh2okcc=w128'. This request has been blocked; the content must be served over HTTPS.