### PR TITLE
migrate to new extra-data format and fix incorrect size

### DIFF
--- a/com.jagex.RuneScape.appdata.xml
+++ b/com.jagex.RuneScape.appdata.xml
@@ -9,6 +9,9 @@
       Play the best MMORPG RuneScape for free. Join the millions of others already exploring the fantasy game world of Gielinor.
     </p>
   </description>
+  <releases>
+    <release version="2.2.4" date="2018-01-22"/>
+  </releases>
   <screenshots>
     <screenshot>
       <image type="source">https://cdn.runescape.com/assets/img/external/news/2016/02/dev-blog/3-NXT-global-illumination.jpg</image>

--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -15,8 +15,7 @@
         "--share=network",
         /* OpenGL */
         "--device=dri",
-        "--persist=Jagex",
-        "--extra-data=runescape.deb:e46f1e4e1969eacbf13d2092c9073ba2c40f876f9434d5a58a267ca474c646ab:3016040::https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.4_amd64.deb"
+        "--persist=Jagex"
     ],
     "build-options" : {
         "cflags": "-O2 -g",
@@ -128,6 +127,14 @@
                 {
                     "type": "file",
                     "path": "com.jagex.RuneScape.appdata.xml"
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "runescape.deb",
+                    "only-arches": ["x86_64"],
+                    "url": "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.4_amd64.deb",
+                    "sha256": "406b3c223b21d638b5eb2de88edf107afb2c7f06912db6ffcc60f74d4d806d82",
+                    "size": 3014650
                 }
             ]
         }


### PR DESCRIPTION
I was getting reports that downloads were failing so I've migrated to the new format which is much more readable and updated the sha and size.

I've also added release tags to the appdata, which you sadly need to increment manually on new releases, but are a flathub requirement now.