### PR TITLE
Add script to get new build information

### DIFF
--- a/bin/debian-update-check.sh
+++ b/bin/debian-update-check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if ! which curl > /dev/null; then
+  echo "Curl is required to check for an updated build."
+  exit 1
+fi
+
+outputLocation="/tmp/rs.deb"
+
+curl -sL -o $outputLocation "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.4_amd64.deb"
+
+echo "The current file size is: $(wc -c < $outputLocation)"
+echo "The current sha256sum is: $(sha256sum $outputLocation | cut -d " " -f 1)"
+
+rm $outputLocation


### PR DESCRIPTION
Adds a script which can be manually triggered to get new build information for the json.

This makes it easier for future updates as well as any new contributors to get the information easily if they wish to contribute an update before someone else notices.