### PR TITLE
WIP: Patch to work with freedesktop 18.07

### DIFF
--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.jagex.RuneScape",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.28",
+    "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "command": "runescape",
     "separate-locales": false,
@@ -107,7 +107,7 @@
                 "install runescape.sh /app/bin/runescape",
                 "install -Dm644 com.jagex.RuneScape.appdata.xml /app/share/appdata/com.jagex.RuneScape.appdata.xml",
                 "cp /usr/bin/ar /app/bin",
-                "cp /usr/lib/libbfd-*.so /app/lib"
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Freedesktop 18.07 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system. Note, gnome sdk is built on freedesktop,
so this will still be necessary when gnome updates.

Obviously don't merge until freedesktop and gnome 3.30 released as stable