### PR TITLE
Move scripts to external files to maintain. Copy them into runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 .DS_Store
-
+.flatpak-builder/

--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -111,29 +111,13 @@
             ],
             "sources": [
                 {
-                    "type": "script",
-                    "dest-filename": "apply_extra",
-                    "commands": [
-                        "ar x runescape.deb",
-                        "tar xf data.tar.xz",
-                        "rm -f runescape.deb control.tar.gz data.tar.xz debian-binary _gpgbuilder",
-                        "mv usr/share/games/runescape-launcher/runescape .",
-                        "mv usr/bin/runescape-launcher .",
-                        "sed -i 's|/usr/share/games/runescape-launcher/|/app/extra/|g' runescape-launcher",
-                        "mkdir -p export/share/applications",
-                        "sed -i 's|/usr/bin/runescape-launcher|runescape|g' usr/share/applications/runescape-launcher.desktop",
-                        "sed s/Icon=runescape/Icon=com.jagex.RuneScape/ usr/share/applications/runescape-launcher.desktop > export/share/applications/com.jagex.RuneScape.desktop",
-                        "mv usr/share/icons export/share/",
-                        "for d in export/share/icons/hicolor/*; do mv $d/apps/runescape.png $d/apps/com.jagex.RuneScape.png; done;",
-                        "rm -rf usr"
-                    ]
+                    "type": "file",
+                    "path": "./scripts/apply_extra.sh",
+                    "dest-filename": "apply_extra"
                 },
                 {
-                    "type": "script",
-                    "commands": [
-                        "[ '$PULSE_LATENCY_MSEC' ] || export PULSE_LATENCY_MSEC='80'",
-                        "exec /app/extra/runescape-launcher $@"
-                    ],
+                    "type": "file",
+                    "path": "./scripts/runescape.sh",
                     "dest-filename": "runescape.sh"
                 },
                 {

--- a/scripts/apply_extra.sh
+++ b/scripts/apply_extra.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+ar x runescape.deb
+
+tar xf data.tar.xz
+
+rm -f runescape.deb control.tar.gz data.tar.xz debian-binary _gpgbuilder
+
+mv usr/share/games/runescape-launcher/runescape .
+
+mv usr/bin/runescape-launcher .
+
+sed -i 's|/usr/share/games/runescape-launcher/|/app/extra/|g' runescape-launcher
+
+mkdir -p export/share/applications
+
+sed -i 's|/usr/bin/runescape-launcher|runescape|g' usr/share/applications/runescape-launcher.desktop
+
+sed s/Icon=runescape/Icon=com.jagex.RuneScape/ usr/share/applications/runescape-launcher.desktop > export/share/applications/com.jagex.RuneScape.desktop
+
+mv usr/share/icons export/share/
+
+for d in export/share/icons/hicolor/*; do
+    mv $d/apps/runescape.png $d/apps/com.jagex.RuneScape.png
+done
+
+rm -rf usr

--- a/scripts/runescape.sh
+++ b/scripts/runescape.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Use the user provided pulseaudio latency or 80ms if unprovided.
+# This is to fix crackling audio issues when running inside of the container.
+[ '$PULSE_LATENCY_MSEC' ] || export PULSE_LATENCY_MSEC='80'
+
+exec /app/extra/runescape-launcher "$@"


### PR DESCRIPTION
Make the scripts external. Maintaining them long-term is easier this way rather than shoe-horning them into JSON.