### PR TITLE
[WIP] chore: add xdotool

### DIFF
--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -100,6 +100,26 @@
             ]
         },
         {
+            "name": "xdotool",
+            "no-autogen": true,
+            "make-args": [
+                "PREFIX=/app"
+            ],
+            "make-install-args": [
+                "PREFIX=/app"
+            ],
+            "cleanup": [
+                "/include"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/jordansissel/xdotool/releases/download/v3.20160805.1/xdotool-3.20160805.1.tar.gz",
+                    "sha256": "35be5ff6edf0c620a0e16f09ea5e101d5173280161772fca18657d83f20fcca8"
+                }
+            ]
+        },
+        {
             "name": "runescape",
             "buildsystem": "simple",
             "build-commands": [

--- a/scripts/runescape.sh
+++ b/scripts/runescape.sh
@@ -4,4 +4,19 @@
 # This is to fix crackling audio issues when running inside of the container.
 [ '$PULSE_LATENCY_MSEC' ] || export PULSE_LATENCY_MSEC='80'
 
-exec /app/extra/runescape-launcher "$@"
+exec /app/extra/runescape-launcher "$@" &
+
+if [ -z "${SHOW_LAUNCHER}" ]; then
+    # The game won't be up instantly. So wait until we see 2 visible RuneScape windows.
+    # While we're waiting, grab the first window ID. This will be the launcher window.
+    until [ $(xdotool search --all --onlyvisible --classname "RuneScape" | wc -l) -eq 2 ]; do
+        [ "$launcherId" ] || launcherId=$(xdotool search --all --onlyvisible --classname "RuneScape")
+        sleep 2
+    done
+
+    # Unmap the launcher window from X. This keeps it running, but hides it from view.
+    # It will close automatically when the game is closed by the user.
+    xdotool windowunmap "$launcherId"
+fi
+
+exit 0


### PR DESCRIPTION
Include xdotool as a required dependency.

Update launcher script to hide the launcher window automatically once the game is loaded.
If the user runs with the SHOW_LAUNCHER environment variable as non-empty, it won't hide the launcher.

Fixes #35 

Do not merge yet, need to test this in Fedora which uses Wayland for the main display server.