### PR TITLE
Update client to 2.2.5.

### DIFF
--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -144,9 +144,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.4_amd64.deb",
-                    "sha256": "79c08db4af6d7f99de4b8de5b6d352751a2238711796d4935626a77207475cbb",
-                    "size": 3019156
+                    "url": "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.5_amd64.deb",
+                    "sha256": "e7f961014c2fbc5ee90c5fe47e342c1fbaa535b19199677175a3afdcd0bea789",
+                    "size": 3900360
                 }
             ]
         }


### PR DESCRIPTION
The client had to be updated since the current version being used by the project (2.2.4) leads to 404 as of the linux client update from 2019-11-11.
Since I found this project to be the alternative when my old configuration stopped working because of this update, I wanted to save you a little bit of time with this update as a thanks.