### PR TITLE
Add x-checker-data

### DIFF
--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -55,7 +55,14 @@
                     ],
                     "url": "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.6_amd64.deb",
                     "sha256": "efa8316025aff6a5ac3e765b2deb61479e5a9b8d059944a182a1839bc3f8d6b1",
-                    "size": 3893860
+                    "size": 3893860,
+                    "x-checker-data": {
+                        "type": "debian-repo",
+                        "package-name": "runescape-launcher",
+                        "root": "https://content.runescape.com/downloads/ubuntu",
+                        "dist": "trusty",
+                        "component": "non-free"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Flathub recently embraced [external-data-checker](https://github.com/flathub/flatpak-external-data-checker). It runs hourly on applications which have `x-checker-data` defined. I know you have your own automation at this point, but it would be cool to switch to the "official" way.