### PR TITLE
Allow PULSE_LATENCY_MSEC to be overridden by runescape.sh

### DIFF
--- a/scripts/apply_extra.sh
+++ b/scripts/apply_extra.sh
@@ -11,6 +11,7 @@ mv usr/share/games/runescape-launcher/runescape .
 mv usr/bin/runescape-launcher .
 
 sed -i 's|/usr/share/games/runescape-launcher/|/app/extra/|g' runescape-launcher
+sed -i 's|export PULSE_LATENCY_MSEC|#export PULSE_LATENCY_MSEC|g' runescape-launcher
 
 mkdir -p export/share/applications
 


### PR DESCRIPTION
Jagex added a hard-coded pulse latency value that was wiping out a user-provided value for this env var. Added a sed command to comment out their hard-code.

Fixes #204 