### PR TITLE
Add x-checker for openssl

### DIFF
--- a/com.jagex.RuneScape.json
+++ b/com.jagex.RuneScape.json
@@ -34,7 +34,12 @@
                 {
                     "type": "archive",
                     "url": "https://www.openssl.org/source/openssl-1.1.1q.tar.gz",
-                    "sha256": "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca"
+                    "sha256": "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 20333,
+                        "url-template": "https://www.openssl.org/source/openssl-$version.tar.gz"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Openssl is a very security sensitive library, so let's make sure it stays updated automatically. x-checker will open PRs whenever there is a newer version available
